### PR TITLE
Remove development calls to dpm().

### DIFF
--- a/uc_stripe.module
+++ b/uc_stripe.module
@@ -577,10 +577,6 @@ function uc_stripe_charge($order_id, $amount, $data) {
         $metadata = array("models" => implode(";", $models));
     }
 
-dpm($metadata,$name="metadata");
-dpm($titles,$name="titles");
-dpm($models,$name="models");
-
     $params = array(
       "amount" => $amount,
       "currency" => strtolower($order->currency),


### PR DESCRIPTION
This breaks checkout (Error 500) when you don’t have https://www.drupal.org/project/devel installed. Closes #1.